### PR TITLE
스터디 참가자 조회 및 스터디 참가/취소 구현

### DIFF
--- a/src/main/java/hae/woori/onceaday/domain/study/StudyController.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/StudyController.java
@@ -1,11 +1,7 @@
 package hae.woori.onceaday.domain.study;
 
-import hae.woori.onceaday.domain.study.dto.StudyCardCreateDto;
-import hae.woori.onceaday.domain.study.dto.StudyCardDeleteDto;
-import hae.woori.onceaday.domain.study.dto.StudyCardListDto;
-import hae.woori.onceaday.domain.study.service.StudyCardCreateService;
-import hae.woori.onceaday.domain.study.service.StudyCardDeleteService;
-import hae.woori.onceaday.domain.study.service.StudyCardListService;
+import hae.woori.onceaday.domain.study.dto.*;
+import hae.woori.onceaday.domain.study.service.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -35,6 +31,8 @@ public class StudyController {
     private final StudyCardCreateService studyCardCreateService;
     private final StudyCardDeleteService studyCardDeleteService;
     private final StudyCardListService studyCardListService;
+    private final StudyCardApplyService studyCardApplyService;
+    private final StudyCardCancelService studyCardCancelService;
 
     @PostMapping("/create")
     @Operation(description = "스터디 카드를 생성합니다. 요청 본문에 UserID와 신청 정보를 포함해야 합니다.",
@@ -76,7 +74,28 @@ public class StudyController {
     }
 
 	//TODO: 4. 스터디 신청 기능
+    @PostMapping("/apply")
+    @Operation(description = "스터디에 신청(참가)합니다.")
+    public StudyCardApplyDto.Response apply(
+            @Valid @RequestBody StudyCardApplyDto.Request request,
+            Authentication authentication
+    ) {
+        String userId = (String) authentication.getPrincipal();
+        log.info("User {} apply card {}", userId, request.cardId());
+        return studyCardApplyService.run(StudyCardApplyDto.RequestWrapper.of(request, userId));
+    }
 
 	//TODO: 5. 스터디 신청 취소 기능
+    @PostMapping("/cancel")
+    @Operation(description = "스터디 신청(참가)을 취소합니다.")
+    public StudyCardCancelDto.Response cancel(
+            @Valid @RequestBody StudyCardCancelDto.Request request,
+            Authentication authentication
+    ) {
+        String userId = (String) authentication.getPrincipal();
+        log.info("User {} cancel card {}", userId, request.cardId());
+        return studyCardCancelService.run(StudyCardCancelDto.RequestWrapper.of(request, userId));
+    }
+
 
 }

--- a/src/main/java/hae/woori/onceaday/domain/study/dto/StudyCardApplyDto.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/dto/StudyCardApplyDto.java
@@ -1,0 +1,20 @@
+package hae.woori.onceaday.domain.study.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class StudyCardApplyDto {
+    @Schema(description = "신청 요청")
+    public record Request(String cardId) {}
+
+    public record RequestWrapper(String cardId, String userId) {
+        public static RequestWrapper of(Request req, String userId) {
+            return new RequestWrapper(req.cardId(), userId);
+        }
+    }
+
+    @Schema(description = "신청 결과")
+    public record Response(
+            boolean success,
+            boolean participated   // 현재 사용자가 참가 목록에 포함되었는지
+    ) {}
+}

--- a/src/main/java/hae/woori/onceaday/domain/study/dto/StudyCardCancelDto.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/dto/StudyCardCancelDto.java
@@ -1,0 +1,20 @@
+package hae.woori.onceaday.domain.study.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public class StudyCardCancelDto {
+    @Schema(description = "취소 요청")
+    public record Request(String cardId) {}
+
+    public record RequestWrapper(String cardId, String userId) {
+        public static RequestWrapper of(Request req, String userId) {
+            return new RequestWrapper(req.cardId(), userId);
+        }
+    }
+
+    @Schema(description = "취소 결과")
+    public record Response(
+            boolean success,
+            boolean participated
+    ) {}
+}

--- a/src/main/java/hae/woori/onceaday/domain/study/dto/StudyCardDto.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/dto/StudyCardDto.java
@@ -2,6 +2,7 @@ package hae.woori.onceaday.domain.study.dto;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.*;
 
 import hae.woori.onceaday.domain.study.vo.StudyUserProfileVo;
 import lombok.Builder;
@@ -22,4 +23,8 @@ public class StudyCardDto {
 	private boolean available;
 	private boolean registered;
 	private boolean isMine;
+	List<String> participantIds;
+	List<String> participantNames;
+	boolean participated;
+
 }

--- a/src/main/java/hae/woori/onceaday/domain/study/dto/StudyCardDto.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/dto/StudyCardDto.java
@@ -21,4 +21,5 @@ public class StudyCardDto {
 	private boolean online;
 	private boolean available;
 	private boolean registered;
+	private boolean isMine;
 }

--- a/src/main/java/hae/woori/onceaday/domain/study/mapper/ParticipantResolver.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/mapper/ParticipantResolver.java
@@ -1,0 +1,37 @@
+package hae.woori.onceaday.domain.study.mapper;
+
+import hae.woori.onceaday.domain.study.external.StudyUserGateway;
+import hae.woori.onceaday.domain.study.vo.StudyUserProfileVo;
+import org.springframework.stereotype.Component;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+@Component
+public class ParticipantResolver {
+
+    private final StudyUserGateway studyUserGateway;
+
+    public ParticipantResolver(StudyUserGateway studyUserGateway) {
+        this.studyUserGateway = studyUserGateway;
+    }
+
+    /**
+     * userIds 리스트를 받아서 id → username 매핑을 생성
+     */
+    public Map<String, String> resolveNames(List<String> userIds) {
+        Map<String, String> idToName = new LinkedHashMap<>();
+        if (userIds == null) return idToName;
+
+        for (String userId : userIds) {
+            StudyUserProfileVo profile = studyUserGateway.getUserProfileById(userId);
+            if (profile != null) {
+                idToName.put(userId, profile.username());
+            } else {
+                idToName.put(userId, null);
+            }
+        }
+        return idToName;
+    }
+}

--- a/src/main/java/hae/woori/onceaday/domain/study/mapper/StudyCardMapper.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/mapper/StudyCardMapper.java
@@ -11,6 +11,11 @@ import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.MappingTarget;
 
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
 @Mapper(componentModel = "spring")
 public interface StudyCardMapper {
     StudyCardDocument createRequestWrapperToStudyCardDocument(StudyCardCreateDto.RequestWrapper request);
@@ -19,7 +24,7 @@ public interface StudyCardMapper {
     @Mapping(target = "isMine",
             expression = "java(studyCardDocument.getUserId().equals(userId))")
     StudyCardDto studyCardDocumentToStudyCardDto(StudyCardDocument studyCardDocument, @Context String userId, @Context
-        StudyUserProfileVo userProfile);
+        StudyUserProfileVo userProfile, @Context ParticipantResolver participantResolver);
 
     @AfterMapping
     default void isRegistered(@MappingTarget StudyCardDto studyCardDto, StudyCardDocument studyCardDocument, @Context String userId, @Context StudyUserProfileVo userProfile) {
@@ -27,6 +32,28 @@ public interface StudyCardMapper {
         studyCardDto.setRegistered(studyCardDocument.getUserId().equals(userId));
         studyCardDto.setUserProfile(userProfile);
     }
+
+    @AfterMapping
+    default void fillParticipants(@MappingTarget StudyCardDto dto,
+                                  StudyCardDocument doc,
+                                  @Context String userId,
+                                  @Context ParticipantResolver resolver) {
+
+        List<String> ids = Optional.ofNullable(doc.getParticipantIds()).orElseGet(List::of);
+        dto.setParticipantIds(ids);
+
+        // 참여 여부
+        dto.setParticipated(userId != null && ids.contains(userId));
+
+        // ID → 이름 변환 (원본 ID 순서 유지)
+        Map<String, String> idToName = resolver.resolveNames(ids);
+        List<String> names = ids.stream()
+                .map(idToName::get)
+                .filter(Objects::nonNull)
+                .toList();
+        dto.setParticipantNames(names);
+    }
+
 
     @AfterMapping
     default void setIsPublic(@MappingTarget StudyCardDocument studyCardDocument) {

--- a/src/main/java/hae/woori/onceaday/domain/study/mapper/StudyCardMapper.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/mapper/StudyCardMapper.java
@@ -16,6 +16,8 @@ public interface StudyCardMapper {
     StudyCardDocument createRequestWrapperToStudyCardDocument(StudyCardCreateDto.RequestWrapper request);
 
     @Mapping(target = "studyCardId", source = "studyCardDocument.id")
+    @Mapping(target = "isMine",
+            expression = "java(studyCardDocument.getUserId().equals(userId))")
     StudyCardDto studyCardDocumentToStudyCardDto(StudyCardDocument studyCardDocument, @Context String userId, @Context
         StudyUserProfileVo userProfile);
 

--- a/src/main/java/hae/woori/onceaday/domain/study/service/StudyCardApplyService.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/service/StudyCardApplyService.java
@@ -1,0 +1,52 @@
+package hae.woori.onceaday.domain.study.service;
+
+import com.mongodb.client.result.UpdateResult;
+import hae.woori.onceaday.domain.SimpleService;
+import hae.woori.onceaday.domain.study.dto.StudyCardApplyDto;
+import hae.woori.onceaday.domain.study.external.StudyUserGateway;
+import hae.woori.onceaday.exception.ClientSideException;
+import hae.woori.onceaday.persistence.document.StudyCardDocument;
+import hae.woori.onceaday.persistence.repository.StudyCardDocumentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.mongodb.core.query.Update;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyCardApplyService implements SimpleService<StudyCardApplyDto.RequestWrapper, StudyCardApplyDto.Response> {
+
+    private final StudyCardDocumentRepository studyCardDocumentRepository;
+    private final StudyUserGateway studyUserGateway;
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public StudyCardApplyDto.Response run(StudyCardApplyDto.RequestWrapper req) {
+        // 사용자 존재 체크
+        if (!studyUserGateway.checkUserExistsById(req.userId())) {
+            throw new ClientSideException("User does not exist: " + req.userId());
+        }
+
+        // 카드 존재/상태 체크
+        StudyCardDocument card = studyCardDocumentRepository.findById(req.cardId())
+                .orElseThrow(() -> new ClientSideException("Study card not found: " + req.cardId()));
+
+        // 참가자일 시 성공으로 간주 (idempotent)
+        if (card.hasParticipant(req.userId())) {
+            return new StudyCardApplyDto.Response(true, true);
+        }
+
+        Query q = Query.query(Criteria.where("_id").is(req.cardId()));
+        Update u = new Update().addToSet("participant_ids", req.userId());
+        UpdateResult r = mongoTemplate.updateFirst(q, u, StudyCardDocument.class);
+
+        boolean participated = r.getModifiedCount() > 0 || studyCardDocumentRepository
+                .findById(req.cardId()).map(c -> c.hasParticipant(req.userId())).orElse(false);
+
+        return new StudyCardApplyDto.Response(true, participated);
+    }
+}
+
+

--- a/src/main/java/hae/woori/onceaday/domain/study/service/StudyCardCancelService.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/service/StudyCardCancelService.java
@@ -1,0 +1,46 @@
+package hae.woori.onceaday.domain.study.service;
+
+import com.mongodb.client.result.UpdateResult;
+import hae.woori.onceaday.domain.SimpleService;
+import hae.woori.onceaday.domain.study.dto.StudyCardCancelDto;
+import hae.woori.onceaday.domain.study.external.StudyUserGateway;
+import hae.woori.onceaday.exception.ClientSideException;
+import hae.woori.onceaday.persistence.document.StudyCardDocument;
+import hae.woori.onceaday.persistence.repository.StudyCardDocumentRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.*;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class StudyCardCancelService implements SimpleService<StudyCardCancelDto.RequestWrapper, StudyCardCancelDto.Response> {
+
+    private final StudyCardDocumentRepository studyCardDocumentRepository;
+    private final StudyUserGateway studyUserGateway;
+    private final MongoTemplate mongoTemplate;
+
+    @Override
+    public StudyCardCancelDto.Response run(StudyCardCancelDto.RequestWrapper req) {
+        if (!studyUserGateway.checkUserExistsById(req.userId())) {
+            throw new ClientSideException("User does not exist: " + req.userId());
+        }
+
+        StudyCardDocument card = studyCardDocumentRepository.findById(req.cardId())
+                .orElseThrow(() -> new ClientSideException("Study card not found: " + req.cardId()));
+
+        // 미참가자일 시 성공으로 간주
+        if (!card.hasParticipant(req.userId())) {
+            return new StudyCardCancelDto.Response(true, false);
+        }
+
+        Query q = Query.query(Criteria.where("_id").is(req.cardId()));
+        Update u = new Update().pull("participant_ids", req.userId());
+        UpdateResult r = mongoTemplate.updateFirst(q, u, StudyCardDocument.class);
+
+        boolean stillParticipated = studyCardDocumentRepository
+                .findById(req.cardId()).map(c -> c.hasParticipant(req.userId())).orElse(false);
+
+        return new StudyCardCancelDto.Response(r.getModifiedCount() >= 0, stillParticipated);
+    }
+}

--- a/src/main/java/hae/woori/onceaday/domain/study/service/StudyCardCreateService.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/service/StudyCardCreateService.java
@@ -25,6 +25,7 @@ public class StudyCardCreateService implements SimpleService<StudyCardCreateDto.
         }
 
         StudyCardDocument studyCardDocument = studyCardMapper.createRequestWrapperToStudyCardDocument(request);
+        studyCardDocument.getParticipantIds().add(request.userId());
         studyCardDocumentRepository.save(studyCardDocument);
         return new StudyCardCreateDto.Response();
     }

--- a/src/main/java/hae/woori/onceaday/domain/study/service/StudyCardListService.java
+++ b/src/main/java/hae/woori/onceaday/domain/study/service/StudyCardListService.java
@@ -1,5 +1,6 @@
 package hae.woori.onceaday.domain.study.service;
 
+import hae.woori.onceaday.domain.study.mapper.ParticipantResolver;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
@@ -22,6 +23,7 @@ public class StudyCardListService implements SimpleService<StudyCardListDto.Requ
 	private final StudyCardDocumentDao studyCardDocumentDao;
 	private final StudyUserGateway studyUserGateway;
 	private final StudyCardMapper studyCardMapper;
+	private final ParticipantResolver participantResolver;
 
 	@Override
 	public StudyCardListDto.Response run(StudyCardListDto.RequestWrapper request) {
@@ -29,7 +31,7 @@ public class StudyCardListService implements SimpleService<StudyCardListDto.Requ
 
 		Page<StudyCardDto> mappedResult = resultPage.map(document -> {
 				StudyUserProfileVo userProfile = studyUserGateway.getUserProfileById(document.getUserId());
-				return studyCardMapper.studyCardDocumentToStudyCardDto(document, request.userId(), userProfile);
+				return studyCardMapper.studyCardDocumentToStudyCardDto(document, request.userId(), userProfile, participantResolver);
 			}
 		);
 

--- a/src/main/java/hae/woori/onceaday/persistence/document/StudyCardDocument.java
+++ b/src/main/java/hae/woori/onceaday/persistence/document/StudyCardDocument.java
@@ -13,6 +13,7 @@ import lombok.Getter;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.*;
 
 @Getter
 @Builder
@@ -49,7 +50,27 @@ public class StudyCardDocument {
 	@Field("is_available")
 	private boolean isAvailable;
 
+	@Builder.Default
+	@Field("participant_ids")
+	private List<String> participantIds = new ArrayList<>();
+
 	public void updatePublicStatus(boolean isPublic) {
 		this.isPublic = isPublic;
 	}
+
+	public boolean addParticipant(String userId) {
+		if (participantIds == null) participantIds = new ArrayList<>();
+		if (participantIds.contains(userId)) return false;
+		participantIds.add(userId);
+		return true;
+	}
+
+	public boolean removeParticipant(String userId) {
+		return participantIds != null && participantIds.remove(userId);
+	}
+
+	public boolean hasParticipant(String userId) {
+		return participantIds != null && participantIds.contains(userId);
+	}
+
 }


### PR DESCRIPTION
**스터디 카드 참가(신청) 및 취소 기능** 추가, 관련 DTO/Service/Mapper 개선

### 주요 변경 내역

1. **StudyController**
    - `/apply`: 스터디 참가 신청 API 추가
    - `/cancel`: 스터디 참가 취소 API 추가
    - `StudyCardApplyService`, `StudyCardCancelService` 의존성 주입
2. **DTO**
    - `StudyCardApplyDto`, `StudyCardCancelDto` 신규 추가
        - `Request`, `RequestWrapper`, `Response` 구조로 설계
    - `StudyCardDto` 확장
        - 참가자 ID/이름 목록, 참여 여부(`participated`) 필드 추가
3. **Service**
    - `StudyCardApplyService`
        - 사용자 존재 여부 확인
        - MongoTemplate + `$addToSet`을 활용한 참가자 등록 (idempotent 보장)
    - `StudyCardCancelService`
        - 사용자 존재 여부 확인
        - MongoTemplate + `$pull`을 활용한 참가자 제거
    - `StudyCardCreateService`
        - 생성 시 카드 작성자를 자동 참가자로 등록
    - `StudyCardListService`
        - `ParticipantResolver` 연동을 통해 참가자 이름 매핑 처리
4. **Mapper**
    - `StudyCardMapper`
        - `ParticipantResolver`를 활용하여 `participantIds → participantNames` 매핑
        - `participated` 여부 설정
    - `ParticipantResolver` 컴포넌트 추가
        - `StudyUserGateway`를 통해 사용자 프로필 조회 및 ID→이름 변환
5. **Document**
    - `StudyCardDocument`에 `participantIds` 필드 추가
    - 참가자 관리 메서드 (`addParticipant`, `removeParticipant`, `hasParticipant`) 제공